### PR TITLE
Use `steady_clock` for all time related actions.

### DIFF
--- a/include/periodic_function/periodic_function.hpp
+++ b/include/periodic_function/periodic_function.hpp
@@ -60,7 +60,7 @@ namespace dp {
             typename = details::is_suitable_callback<Callback>>
   class periodic_function final {
   public:
-    using time_type = std::chrono::system_clock::duration;
+    using time_type = std::chrono::steady_clock::duration;
 
     periodic_function(Callback &&callback, const time_type &interval) noexcept
         : interval_(interval), callback_(std::forward<Callback>(callback)) {}
@@ -127,7 +127,7 @@ namespace dp {
     void start_internal() {
       if (is_running()) stop();
       runner_ = std::thread([this]() {
-        const auto thread_start = std::chrono::high_resolution_clock::now();
+        const auto thread_start = std::chrono::steady_clock::now();
         // pre-calculate time
         auto future_time = thread_start + interval_;
 
@@ -141,13 +141,13 @@ namespace dp {
           }
 
           // execute the callback and measure execution time
-          const auto callback_start = std::chrono::high_resolution_clock::now();
+          const auto callback_start = std::chrono::steady_clock::now();
           // suppress exceptions
           try {
             callback_();
           } catch (...) {
           }
-          const auto callback_end = std::chrono::high_resolution_clock::now();
+          const auto callback_end = std::chrono::steady_clock::now();
           const time_type callback_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
               callback_end - callback_start);
           const time_type append_time


### PR DESCRIPTION
Using `std::system_clock` for periodic execution opens the code up for
changes in the system time, which is probably not what is desired. A
function for executing a function at a specific point in time would
prefer the use of `std::system_clock` to ensure that the correct local
time is used. For scheduling an event every 300ms it is preferable to
have a steady count.

Futher, the use of `std::high_resolution_clock` is misleading as it
does not refer to the same clock in every implementation. Indeed, the
[standard](wg21.link/std17) (23.17.7.3) says as much:

> Objects of classhigh_resolution_clockrepresent clocks with the
> shortest tick period. `high_resolution_clock` may be a synonym
> for `system_clock` or `steady_clock`.

The following answer on [Stack Overflow](https://bit.ly/36XDXUC) gives
some details about implementation status which can be summarized as:

 * GCC:  `using high_resolution_clock = system_clock;`
 * MSVC: `using high_resolution_clock = steady_clock;`

libc++ is slightly more complex and depends on whether or not
`_LIBCPP_HAS_NO_MONOTONIC_CLOCK` is defined:
 * not defined: `typedef steady_clock high_resolution_clock;`
 * defined:     `typedef system_clock high_resolution_clock;`

This may lead to some problems if this code is run on different
platforms with users expecting consistency.

Signed-off-by: David Brown <d.brown@bigdavedev.com>